### PR TITLE
feat: add makeup

### DIFF
--- a/app/src/main/java/com/example/chuibbo_android/api/MakeupApi.kt
+++ b/app/src/main/java/com/example/chuibbo_android/api/MakeupApi.kt
@@ -1,0 +1,31 @@
+package com.example.chuibbo_android.api
+
+import com.example.chuibbo_android.api.request.MakeupRequest
+import com.example.chuibbo_android.api.request.MakeupStrongRequest
+import okhttp3.MultipartBody
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.*
+import java.util.HashMap
+
+interface MakeupApi {
+    @GET
+    fun downloadFile(@Url fileUrl:String): Call<ResponseBody>
+
+    @Multipart
+    @POST("/api/upload")
+    fun uploadFile(@Part file: MultipartBody.Part): Call<String>
+
+    @POST("/api/parameter")
+    fun uploadParameter(@Body param: HashMap<String, Int>): Call<MakeupRequest>
+
+    @POST("/api/strong")
+    fun uploadStrong(@Body strong: Int): Call<MakeupStrongRequest>
+
+    @POST("/api/makeup")
+    fun makeUpFace(@Body strong: Int): Call<MakeupStrongRequest>
+
+    companion object {
+        val instance = ApiGenerator().generate(MakeupApi::class.java)
+    }
+}

--- a/app/src/main/java/com/example/chuibbo_android/api/request/MakeupRequest.kt
+++ b/app/src/main/java/com/example/chuibbo_android/api/request/MakeupRequest.kt
@@ -1,0 +1,9 @@
+package com.example.chuibbo_android.api.request
+
+data class MakeupRequest(
+    val rColor: Int,
+    val gColor: Int,
+    val bColor: Int,
+    val size: Int,
+    val index: Int
+)

--- a/app/src/main/java/com/example/chuibbo_android/api/request/MakeupStrongRequest.kt
+++ b/app/src/main/java/com/example/chuibbo_android/api/request/MakeupStrongRequest.kt
@@ -1,0 +1,5 @@
+package com.example.chuibbo_android.api.request
+
+data class MakeupStrongRequest(
+    var strong: Int = 0
+)

--- a/app/src/main/java/com/example/chuibbo_android/background/BackgroundSynthesisFragment.kt
+++ b/app/src/main/java/com/example/chuibbo_android/background/BackgroundSynthesisFragment.kt
@@ -1,13 +1,16 @@
 package com.example.chuibbo_android.background
 
 import android.annotation.SuppressLint
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
 import com.example.chuibbo_android.R
 import com.example.chuibbo_android.correction.FaceCorrectionFragment
@@ -15,9 +18,9 @@ import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import kotlinx.android.synthetic.main.background_synthesis_fragment.*
 import kotlinx.android.synthetic.main.main_activity.*
+import kotlinx.android.synthetic.main.overall_synthesis_confirm_item.*
 
 class BackgroundSynthesisFragment : Fragment() {
-    private lateinit var next_button: ImageButton
 
     @SuppressLint("ResourceAsColor")
     private fun changeView(index: Int) {

--- a/app/src/main/java/com/example/chuibbo_android/camera/ConfirmFragment.kt
+++ b/app/src/main/java/com/example/chuibbo_android/camera/ConfirmFragment.kt
@@ -1,5 +1,7 @@
 package com.example.chuibbo_android.camera
 
+import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
@@ -34,6 +36,10 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
+
 
 class ConfirmFragment : Fragment() {
     private lateinit var filePath: String
@@ -118,9 +124,8 @@ class ConfirmFragment : Fragment() {
                         call: Call<ResumePhotoUploadResponse>,
                         response: Response<ResumePhotoUploadResponse>
                     ) {
-                        if (response?.isSuccessful) {
+                        if (response.isSuccessful) {
                             val result = response.body()?.code
-                            println(result)
                             when (result) {
                                 1 -> {
                                     val decode_img = Base64.decode(response.body()?.data, Base64.DEFAULT)
@@ -128,7 +133,9 @@ class ConfirmFragment : Fragment() {
 
                                     activateProgressBar(false) // remove progress bar
 
-                                    setFragmentResult("requestBitmapKey", bundleOf("bundleKey" to bitmapResultImage))
+                                    saveBitmapToJpeg(bitmapResultImage, "result")
+
+                                    setFragmentResult("requestBitmapKey", bundleOf("bundleBitmapKey" to bitmapResultImage))
                                     Toast.makeText(context, "File Uploaded Successfully...", Toast.LENGTH_LONG).show()
 
                                     val transaction = activity?.supportFragmentManager!!.beginTransaction()
@@ -181,6 +188,24 @@ class ConfirmFragment : Fragment() {
                 btn_confirm.isEnabled = true
                 btn_select_again.isEnabled = true
             }
+        }
+    }
+
+    private fun saveBitmapToJpeg(bitmap: Bitmap, name: String) {
+        val storage: File = activity?.cacheDir!!
+        val fileName = "$name.jpg"
+
+        val tempFile = File(storage, fileName)
+        try {
+            tempFile.createNewFile()
+            val out = FileOutputStream(tempFile)
+            // compress 함수를 사용해 스트림에 비트맵을 저장합니다.
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+            out.close()
+        } catch (e: FileNotFoundException) {
+            Log.e("MyTag", "FileNotFoundException : " + e.message)
+        } catch (e: IOException) {
+            Log.e("MyTag", "IOException : " + e.message)
         }
     }
 }

--- a/app/src/main/java/com/example/chuibbo_android/camera/SynthesisConfirmFragment.kt
+++ b/app/src/main/java/com/example/chuibbo_android/camera/SynthesisConfirmFragment.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.ViewModelProvider
 import com.example.chuibbo_android.R
@@ -22,6 +24,7 @@ class SynthesisConfirmFragment : Fragment() {
 
     private lateinit var vm: ImageViewModel
     private val adapter = Adapter()
+    private lateinit var result: Bitmap
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -46,7 +49,7 @@ class SynthesisConfirmFragment : Fragment() {
 //        }
 
         setFragmentResultListener("requestBitmapKey") { key, bundle ->
-            val result = bundle.getParcelable<Bitmap>("bundleKey")
+            result = bundle.getParcelable<Bitmap>("bundleBitmapKey")!!
             img_synthesis!!.setImageBitmap(result)
         }
 

--- a/app/src/main/java/com/example/chuibbo_android/correction/FaceCorrectionFragment.kt
+++ b/app/src/main/java/com/example/chuibbo_android/correction/FaceCorrectionFragment.kt
@@ -1,17 +1,39 @@
 package com.example.chuibbo_android.correction
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.SeekBar
+import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import com.example.chuibbo_android.R
+import com.example.chuibbo_android.api.MakeupApi
+import com.example.chuibbo_android.api.request.MakeupRequest
+import com.example.chuibbo_android.api.request.MakeupStrongRequest
 import com.example.chuibbo_android.download.DownloadFragment
 import com.google.android.material.tabs.TabLayout
 import kotlinx.android.synthetic.main.face_correction_fragment.*
+import kotlinx.android.synthetic.main.face_correction_makeup_fragment.*
 import kotlinx.android.synthetic.main.main_activity.*
+import okhttp3.MultipartBody
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.File
+import java.io.InputStream
+import java.util.HashMap
 
-class FaceCorrectionFragment : Fragment() {
+class FaceCorrectionFragment : Fragment(), IUploadCallback {
+    private lateinit var file: File
+    private val makeupService = MakeupApi.instance
 
     private fun changeView(index: Int) {
         when (index) {
@@ -51,6 +73,9 @@ class FaceCorrectionFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        file = File(activity?.cacheDir?.toString()+"/result.jpg")
+        uploadFile()
+        activity?.img_face_correction?.setImageBitmap(BitmapFactory.decodeFile(activity?.cacheDir?.toString()+"/result.jpg"))
 
         activity?.btn_next!!.visibility = View.VISIBLE
         activity?.btn_next!!.setOnClickListener {
@@ -76,9 +101,39 @@ class FaceCorrectionFragment : Fragment() {
         })
     }
 
+    //서버로 이미지 업로드
+    private fun uploadFile() {
+        if (file != null) {
+            val requestBody = ProgressRequestBody(file, this)
+            val body = MultipartBody.Part.createFormData("image", file.name, requestBody)
+
+            Thread(Runnable {
+                makeupService.uploadFile(body)
+                    .enqueue(object : Callback<String> {
+                        override fun onResponse(call: Call<String>, response: Response<String>) {
+                            // image_view.setImageURI(selectedUri)
+                            Log.d("결과", "성공 : //{response.raw()}")
+                            Toast.makeText(context, "사진 전송에 성공하였습니다.", Toast.LENGTH_SHORT).show()
+                        }
+
+                        override fun onFailure(call: Call<String>, t: Throwable) {
+                            Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
+                        }
+
+                    })
+            }).start()
+        } else {
+            Toast.makeText(context, "이 이미지를 업로드 할 수 없습니다.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         activity?.process3!!.visibility = View.GONE
         activity?.btn_next!!.visibility = View.GONE
+    }
+
+    override fun onProgressupdate(percent: Int) {
+
     }
 }

--- a/app/src/main/java/com/example/chuibbo_android/correction/FaceCorrectionMakeupFragment.kt
+++ b/app/src/main/java/com/example/chuibbo_android/correction/FaceCorrectionMakeupFragment.kt
@@ -1,19 +1,155 @@
 package com.example.chuibbo_android.correction
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.SeekBar
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.example.chuibbo_android.R
+import com.example.chuibbo_android.api.ApiGenerator
+import com.example.chuibbo_android.api.MakeupApi
+import com.example.chuibbo_android.api.request.MakeupRequest
+import com.example.chuibbo_android.api.request.MakeupStrongRequest
+import kotlinx.android.synthetic.main.face_correction_fragment.*
+import kotlinx.android.synthetic.main.face_correction_makeup_fragment.*
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.InputStream
+import java.util.*
 
 class FaceCorrectionMakeupFragment : Fragment() {
+    private val makeupService = MakeupApi.instance
+    private var flagLip = false
+    private var flagCheek = false
+    private var flagEyebrow = false
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         return inflater.inflate(R.layout.face_correction_makeup_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 메이크업 강도 조절 바
+        activity?.seekbar_makeup?.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener{
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                uploadStrong(progress)
+            }
+
+            override fun onStartTrackingTouch(p0: SeekBar?) {
+
+            }
+
+            override fun onStopTrackingTouch(p0: SeekBar?) {
+                makeupFace()
+            }
+        })
+
+        img_lipstick?.setOnClickListener {
+            when(flagLip) {
+                true ->
+                    activity?.seekbar_makeup?.visibility = View.INVISIBLE
+                false -> {
+                    activity?.seekbar_makeup?.visibility = View.VISIBLE
+                    uploadParameter(247, 40, 57, 33, 2)
+                }
+            }
+            // TODO: 다양한 컬러 사용자로부터 선택할 수 있도록 하는 기능 추가
+        }
+        img_cheek?.setOnClickListener {
+            when(flagCheek) {
+                true ->
+                    activity?.seekbar_makeup?.visibility = View.INVISIBLE
+                false -> {
+                    activity?.seekbar_makeup?.visibility = View.VISIBLE
+                    uploadParameter(247, 40, 57, 100, 3)
+                }
+            }
+            // TODO: 다양한 컬러 사용자로부터 선택할 수 있도록 하는 기능 추가
+            uploadParameter(247, 40, 57, 100, 3)
+        }
+        img_eyebrow?.setOnClickListener {
+            when(flagEyebrow) {
+                true ->
+                    activity?.seekbar_makeup?.visibility = View.INVISIBLE
+                false -> {
+                    activity?.seekbar_makeup?.visibility = View.VISIBLE
+                    // TODO: 눈썹 기능 추가
+                    //uploadParameter(247, 40, 57, 100, 1)
+                }
+            }
+        }
+    }
+
+    // 파라미터 전달
+    private fun uploadParameter(r:Int, g:Int, b:Int, size:Int, index:Int){
+        val input = HashMap<String, Int>()
+        input["rColor"] = r
+        input["gColor"] = g
+        input["bColor"] = b
+        input["size"] = size
+        input["index"] = index
+        makeupService.uploadParameter(input).enqueue(object : Callback<MakeupRequest>{
+            override fun onResponse(call: Call<MakeupRequest>, response: Response<MakeupRequest>) {
+                downloadFile()
+            }
+
+            override fun onFailure(call: Call<MakeupRequest>, t: Throwable) {
+            }
+        })
+    }
+
+    //서버로 이미지 다운로드
+    private fun downloadFile() {
+        makeupService.downloadFile(ApiGenerator.HOST+"/static/Output.jpg/")
+            .enqueue(object : Callback<ResponseBody>{
+                override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
+                    val inputS : InputStream = response.body()!!.byteStream()
+                    val bmp : Bitmap = BitmapFactory.decodeStream(inputS)
+                    activity?.img_face_correction?.setImageBitmap(bmp)
+                    Toast.makeText(context, "메이크업에 성공하였습니다.", Toast.LENGTH_SHORT).show()
+                }
+
+                override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                    Toast.makeText(context, t.message, Toast.LENGTH_SHORT).show()
+                }
+            })
+    }
+
+    //메이크업 강도 전달
+    private fun uploadStrong(strong: Int) {
+        makeupService.uploadStrong(strong).enqueue(object : Callback<MakeupStrongRequest>{
+            override fun onResponse(call: Call<MakeupStrongRequest>, response: Response<MakeupStrongRequest>) {
+                downloadFile()
+            }
+
+            override fun onFailure(call: Call<MakeupStrongRequest>, t: Throwable) {
+            }
+        })
+    }
+
+    //메이크업 요청
+    private fun makeupFace() {
+        val strong = 1
+        makeupService.makeUpFace(strong).enqueue(object: Callback<MakeupStrongRequest> {
+            override fun onResponse(call: Call<MakeupStrongRequest>, response: Response<MakeupStrongRequest>) {
+                downloadFile()
+            }
+
+            override fun onFailure(call: Call<MakeupStrongRequest>, t: Throwable) {
+                Toast.makeText(context, "makeupFaceFailed"+t.message, Toast.LENGTH_SHORT).show()
+            }
+        })
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/example/chuibbo_android/correction/IUploadCallback.kt
+++ b/app/src/main/java/com/example/chuibbo_android/correction/IUploadCallback.kt
@@ -1,0 +1,5 @@
+package com.example.chuibbo_android.correction
+
+interface IUploadCallback {
+    fun onProgressupdate(percent:Int)
+}

--- a/app/src/main/java/com/example/chuibbo_android/correction/ProgressRequestBody.kt
+++ b/app/src/main/java/com/example/chuibbo_android/correction/ProgressRequestBody.kt
@@ -1,0 +1,50 @@
+package com.example.chuibbo_android.correction
+
+import android.os.Handler
+import android.os.Looper
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody
+import okio.BufferedSink
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+import kotlin.jvm.Throws
+
+class ProgressRequestBody(private val file: File,
+                          private val listener:IUploadCallback): RequestBody() {
+    companion object{
+        private val DEFAULT_BUFFER_SIZE = 4096
+    }
+    override fun contentType(): MediaType? {
+        return "image/*".toMediaTypeOrNull()
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(sink: BufferedSink) {
+        val fileLength = file.length()
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val `in` = FileInputStream(file)
+        var uploaded : Long = 0
+        try{
+            var read:Int
+            val handler = Handler(Looper.getMainLooper())
+            while(`in`.read(buffer).let {
+                    read = it;  it!=-1
+                })
+            {
+                handler.post(ProgressUpdater(uploaded,fileLength))
+                uploaded+=read.toLong()
+                sink.write(buffer,0,read)
+            }
+        }finally {
+            `in`.close()
+        }
+    }
+
+    inner class ProgressUpdater(private val uploaded: Long, private val fileLength: Long) : Runnable {
+        override fun run() {
+            listener.onProgressupdate((100*uploaded / fileLength).toInt())
+        }
+    }
+}

--- a/app/src/main/java/com/example/chuibbo_android/guideline/GuidelineContentsFragment.kt
+++ b/app/src/main/java/com/example/chuibbo_android/guideline/GuidelineContentsFragment.kt
@@ -62,7 +62,7 @@ class GuidelineContentsFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        activity?.btn_next!!.visibility = View.GONE
+        activity?.btn_next?.visibility = View.GONE
     }
 
     companion object {

--- a/app/src/main/java/com/example/chuibbo_android/utils/URIPathHelper.kt
+++ b/app/src/main/java/com/example/chuibbo_android/utils/URIPathHelper.kt
@@ -10,7 +10,7 @@ import android.provider.DocumentsContract
 import android.provider.MediaStore
 
 class URIPathHelper {
-    // room dabase 에 저장하기 위해 갤러리에서 가져온 사진 경로 설정
+    // room database 에 저장하기 위해 갤러리에서 가져온 사진 경로 설정
     fun getPath(context: Context, uri: Uri): String? {
         val isKitKatorAbove = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
 

--- a/app/src/main/res/layout/face_correction_fragment.xml
+++ b/app/src/main/res/layout/face_correction_fragment.xml
@@ -9,11 +9,10 @@
 
     <ImageView
         android:id="@+id/img_face_correction"
-        android:layout_width="210dp"
-        android:layout_height="285dp"
+        android:layout_width="250dp"
+        android:layout_height="315dp"
         android:layout_marginTop="20dp"
         android:background="@drawable/photo_frame"
-        android:src="@drawable/background_synthesis_sample"
         app:layout_constraintHorizontal_bias="0.496"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/face_correction_makeup_fragment.xml
+++ b/app/src/main/res/layout/face_correction_makeup_fragment.xml
@@ -15,23 +15,22 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         android:paddingLeft="40dp"
-        android:paddingRight="40dp"
-        android:visibility="gone">
+        android:paddingRight="40dp">
 
-        <com.google.android.material.slider.Slider
-            android:id="@+id/slider"
-            android:layout_width="wrap_content"
+        <SeekBar
+            android:id="@+id/seekbar_makeup"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stepSize="10.0"
-            android:valueFrom="0.0"
-            android:valueTo="100.0"
-            app:barrierMargin="30dp"
+            android:min="5"
+            android:max="30"
+            android:progress="15"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:thumbColor="@color/main_blue"
             app:thumbRadius="7dp"
-            app:trackHeight="2dp" />
+            app:trackHeight="2dp"
+            android:visibility="gone"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
###  합성 결과를 내부저장소 캐시에 저장하도록 하였습니다.
배경 합성부분에서 사진을 사용하시려면,
``` kotlin
val file = File(activity?.cacheDir?.toString()+"/result.jpg")
```
이렇게 파일을 불러올 수 있고,
``` kotlin
activity?.img_face_correction?.setImageBitmap(BitmapFactory.decodeFile(activity?.cacheDir?.toString()+"/result.jpg"))
```
이렇게 이미지뷰에 사진을 띄울 수 있습니다.
추후 배경 합성 기능을 완성하여 새로 생성된 이미지를 캐시에 저장하려면 `ConfirmFragment.kt` 의 `saveBitmapToJpeg()` 메서드를 사용하면 될 것 같습니다.

###  메이크업 기능 추가
전체적인 프로세스는 다음과 같습니다.

1. `FaceCorrectionFragment.kt` 에서 `/api/upload` 를 호출하여 서버로 (배경 합성된)이미지를 전송합니다.
2. `FaceCorrectionMakeupFragment.kt` 에서 슬라이드바의 위치에 따라 해당 부분에 rgb 색상과 강도를 서버로 전달하여 메이크업을 요청합니다. 
3. 서버에서 메이크업된 이미지를 다운로드하여 이미지뷰에 띄웁니다.

### 추후 개선할 부분
- 눈썹 기능 
- 메이크업 색조 다양화
